### PR TITLE
Add cursor-follow effect and fix language default

### DIFF
--- a/src/components/MouseFollow.tsx
+++ b/src/components/MouseFollow.tsx
@@ -20,7 +20,7 @@ export const MouseFollow = component$(() => {
     <div
       class="pointer-events-none fixed inset-0 z-30 transition duration-300"
       style={{
-        background: `radial-gradient(600px at ${mouseX.value}px ${mouseY.value}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
+        background: `radial-gradient(600px at ${mouseX.value}px ${mouseY.value}px, rgba(139, 92, 246, 0.2), transparent 80%)`,
       }}
     />
   );

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -4,8 +4,7 @@ import {
   Slot,
   useContextProvider,
   useStore,
-  $,
-  useVisibleTask$,
+  $
 } from "@builder.io/qwik";
 import { LanguageToggle } from "../components/LanguageToggle";
 
@@ -27,9 +26,6 @@ export const LanguageProvider = component$(() => {
     store.current = store.current === "en" ? "es" : "en";
   });
 
-  useVisibleTask$(() => {
-    store.current = navigator.language.startsWith("es") ? "es" : "en";
-  });
 
   useContextProvider(LanguageContext, store);
 


### PR DESCRIPTION
## Summary
- keep English as the default language
- tweak cursor follow gradient color

## Testing
- `npm run build` *(fails: Cannot find module '@builder.io/qwik')*