### PR TITLE
Add software services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/app.css" />
+    <title>Agustin Dev - Services</title>
+  </head>
+  <body class="min-h-screen w-full m-0 p-0">
+    <div id="app"></div>
+    <script type="module" src="/src/main-services.tsx"></script>
+  </body>
+</html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,11 +14,21 @@ export const Header = component$(() => {
       </h1>
       <p class="text-2xl text-gray-300 mb-4">{t.role}</p>
       <div class="flex justify-center gap-4 text-gray-300">
-        <a href="mailto:bereciartua.agustin@gmail.com" class="hover:text-purple-400 transition-colors">
+        <a
+          href="mailto:bereciartua.agustin@gmail.com"
+          class="hover:text-purple-400 transition-colors"
+        >
           📧 bereciartua.agustin@gmail.com
         </a>
         <span>|</span>
-        <a href="tel:+5693570521" class="hover:text-purple-400 transition-colors">
+        <a href="/services.html" class="hover:text-purple-400 transition-colors">
+          {t.servicesTitle}
+        </a>
+        <span>|</span>
+        <a
+          href="tel:+5693570521"
+          class="hover:text-purple-400 transition-colors"
+        >
           📱 +569 3570 5212
         </a>
       </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,0 +1,28 @@
+import { component$, useContext } from '@builder.io/qwik';
+import { LanguageContext } from '../context/LanguageContext';
+import { translations } from '../i18n/translations';
+
+export const Services = component$(() => {
+  const languageStore = useContext(LanguageContext);
+  const t = translations[languageStore.current];
+
+  return (
+    <section class="max-w-4xl mx-auto mb-16">
+      <h2 class="text-3xl font-bold mb-4 text-purple-400">{t.servicesTitle}</h2>
+      <p class="mb-6 text-gray-300">{t.servicesIntro}</p>
+      <div class="space-y-4">
+        {t.serviceList.map((service: { title: string; description: string }) => (
+          <div
+            key={service.title}
+            class="card-interactive bg-gray-800/30 p-4 rounded-lg hover:bg-gray-800/50 transition-all duration-300"
+          >
+            <h3 class="text-xl font-semibold mb-2 hover:text-purple-400 transition-colors">
+              {service.title}
+            </h3>
+            <p class="text-gray-300">{service.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+});

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -8,6 +8,26 @@ export const translations = {
     tools: 'Tools & Platforms',
     frameworks: 'Frameworks',
     other: 'Other Skills',
+    servicesTitle: 'Services',
+    servicesIntro: 'I offer software engineering and AI solutions tailored to your needs.',
+    serviceList: [
+      {
+        title: 'AI Solutions',
+        description: 'Design and implementation of machine learning models and automation tools.'
+      },
+      {
+        title: 'Custom Web & Mobile Development',
+        description: 'Creation of applications adapted to your business goals.'
+      },
+      {
+        title: 'API Design & Integration',
+        description: 'Integration of third-party services and development of robust APIs.'
+      },
+      {
+        title: 'Cloud Architecture',
+        description: 'Setup of scalable infrastructure with CI/CD pipelines.'
+      }
+    ],
     companies: {
       buk: {
         role: 'Senior Software Engineer',
@@ -60,6 +80,26 @@ export const translations = {
     tools: 'Herramientas y Plataformas',
     frameworks: 'Frameworks',
     other: 'Otras Habilidades',
+    servicesTitle: 'Servicios',
+    servicesIntro: 'Ofrezco servicios de ingeniería de software e IA adaptados a tus necesidades.',
+    serviceList: [
+      {
+        title: 'Soluciones de IA',
+        description: 'Diseño e implementación de modelos de machine learning y herramientas de automatización.'
+      },
+      {
+        title: 'Desarrollo Web y Móvil a Medida',
+        description: 'Aplicaciones creadas según los objetivos de tu negocio.'
+      },
+      {
+        title: 'Diseño e Integración de APIs',
+        description: 'Integración de servicios de terceros y desarrollo de APIs robustas.'
+      },
+      {
+        title: 'Arquitectura en la Nube',
+        description: 'Configuración de infraestructura escalable con pipelines CI/CD.'
+      }
+    ],
     companies: {
       buk: {
         role: 'Ingeniero de Software Senior',

--- a/src/main-services.tsx
+++ b/src/main-services.tsx
@@ -1,0 +1,6 @@
+import '@builder.io/qwik/qwikloader.js';
+import { render } from '@builder.io/qwik';
+import './index.css';
+import { ServicesApp } from './services-app';
+
+render(document.getElementById('app') as HTMLElement, <ServicesApp />);

--- a/src/services-app.tsx
+++ b/src/services-app.tsx
@@ -1,0 +1,20 @@
+import { component$ } from '@builder.io/qwik';
+import { LanguageProvider } from './context/LanguageContext';
+import { Services } from './components/Services';
+import { SocialLinks } from './components/SocialLinks';
+import { MouseFollow } from './components/MouseFollow';
+import './app.css';
+
+export const ServicesApp = component$(() => {
+  return (
+    <LanguageProvider>
+      <div class="min-h-screen w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white relative overflow-hidden">
+        <MouseFollow />
+        <div class="relative z-10">
+          <Services />
+          <SocialLinks />
+        </div>
+      </div>
+    </LanguageProvider>
+  );
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 export default {
   content: [
     "./index.html",
+    "./services.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,12 @@ import { qwikVite } from "@builder.io/qwik/optimizer";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [qwikVite({ client: { input: "src/main.tsx" } })],
+  plugins: [
+    qwikVite({ client: { input: ["src/main.tsx", "src/main-services.tsx"] } })
+  ],
   build: {
     rollupOptions: {
-      input: "index.html",
+      input: ["index.html", "services.html"],
     },
   },
 });


### PR DESCRIPTION
## Summary
- add `services.html` entrypoint
- create `Services` component and `services-app`
- include new translations for service offerings in English and Spanish
- update header with link to the services page
- update Tailwind and Vite configs for new page

## Testing
- `npm run build` *(fails: cannot find module)*
- `npx tsc -p tsconfig.app.json` *(fails: cannot find module)*