### PR TITLE
feat: add zoomable canvas component

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,20 +5,23 @@ import { Experience } from "./components/Experience";
 import { Skills } from "./components/Skills";
 import { SocialLinks } from "./components/SocialLinks";
 import { MouseFollow } from "./components/MouseFollow";
+import { ZoomCanvas } from "./components/ZoomCanvas";
 import "./app.css";
 
 export const App = component$(() => {
   return (
     <LanguageProvider>
-      <div class="min-h-screen w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white relative overflow-hidden">
-        <MouseFollow />
-        <div class="relative z-10">
-          <Header />
-          <Experience />
-          <Skills />
-          <SocialLinks />
+      <ZoomCanvas>
+        <div class="min-h-screen w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white relative overflow-hidden">
+          <MouseFollow />
+          <div class="relative z-10">
+            <Header />
+            <Experience />
+            <Skills />
+            <SocialLinks />
+          </div>
         </div>
-      </div>
+      </ZoomCanvas>
     </LanguageProvider>
   );
 });

--- a/src/components/ZoomCanvas.tsx
+++ b/src/components/ZoomCanvas.tsx
@@ -1,0 +1,41 @@
+import { component$, useSignal, $, Slot } from '@builder.io/qwik';
+
+export const ZoomCanvas = component$(() => {
+  const scale = useSignal(1);
+
+  const zoomIn = $(() => {
+    scale.value = Math.min(2, scale.value + 0.2);
+  });
+
+  const zoomOut = $(() => {
+    scale.value = Math.max(0.5, scale.value - 0.2);
+  });
+
+  return (
+    <>
+      <div class="fixed bottom-4 right-4 z-50 flex gap-2">
+        <button
+          onClick$={zoomOut}
+          class="bg-gray-800 px-3 py-1 rounded hover:bg-gray-700"
+        >
+          -
+        </button>
+        <button
+          onClick$={zoomIn}
+          class="bg-gray-800 px-3 py-1 rounded hover:bg-gray-700"
+        >
+          +
+        </button>
+      </div>
+      <div
+        style={{
+          transform: `scale(${scale.value})`,
+          transformOrigin: 'center top',
+          transition: 'transform 0.3s ease'
+        }}
+      >
+        <Slot />
+      </div>
+    </>
+  );
+});


### PR DESCRIPTION
## Summary
- introduce `ZoomCanvas` to enable zooming the app layout
- wrap application content with `ZoomCanvas`

## Testing
- `npm install` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683cffe42ac88321ae1062cb524ae282