### PR TITLE
feat: add ascii islands animation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { Skills } from "./components/Skills";
 import { SocialLinks } from "./components/SocialLinks";
 import { MouseFollow } from "./components/MouseFollow";
 import { ZoomCanvas } from "./components/ZoomCanvas";
+import { AsciiOcean } from "./components/AsciiOcean";
 import "./app.css";
 
 export const App = component$(() => {
@@ -14,6 +15,7 @@ export const App = component$(() => {
       <ZoomCanvas>
         <div class="min-h-screen w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white relative overflow-hidden">
           <MouseFollow />
+          <AsciiOcean />
           <div class="relative z-10">
             <Header />
             <Experience />

--- a/src/components/AsciiOcean.tsx
+++ b/src/components/AsciiOcean.tsx
@@ -1,0 +1,34 @@
+import { component$ } from '@builder.io/qwik';
+
+export const AsciiOcean = component$(() => {
+  const islands = [
+`  /\\
+ /  \\
+/____\\
+  ||`,
+`   /\\
+  /--\\
+ /____\\
+   ||`,
+`   /\\
+  /  \\
+ /____\\
+ /||||\\`
+  ];
+
+  return (
+    <div class="ascii-ocean absolute inset-0 overflow-hidden pointer-events-none">
+      {islands.map((art, index) => (
+        <pre
+          key={index}
+          class="ascii-island"
+          style={{
+            left: `${10 + index * 30}%`,
+            top: `${20 + index * 15}px`,
+            animationDelay: `${index * 1.5}s`,
+          }}
+        >{art}</pre>
+      ))}
+    </div>
+  );
+});

--- a/src/index.css
+++ b/src/index.css
@@ -91,3 +91,20 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: #5a5a5a;
 }
+/* ASCII ocean effect */
+.ascii-ocean {
+  font-family: monospace;
+  z-index: 5;
+}
+
+.ascii-island {
+  position: absolute;
+  white-space: pre;
+  opacity: 0.8;
+  animation: float 6s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}


### PR DESCRIPTION
## Summary
- add `AsciiOcean` component with simple ASCII islands
- style islands with floating animation
- use the new component in `App`

## Testing
- `npm run build` *(fails: Cannot find module '@builder.io/qwik')*

------
https://chatgpt.com/codex/tasks/task_b_683d0602ef088321bbce44ebc40c12d0