### PR TITLE
fix: add type declarations for three modules

### DIFF
--- a/src/types/three-modules.d.ts
+++ b/src/types/three-modules.d.ts
@@ -1,0 +1,2 @@
+declare module 'three';
+declare module 'three/examples/jsm/controls/OrbitControls';


### PR DESCRIPTION
## Summary
- declare missing 'three' modules for TypeScript

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm run build` *(fails: packages missing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_683e3f967a008321b63f819e78f08ff5