### PR TITLE
feat: add Bitua.io experience

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -13,9 +13,22 @@ interface Experience {
 
 const getExperiences = (lang: "en" | "es"): Experience[] => [
   {
+    company: "Bitua.io",
+    url: "https://bitua.io/",
+    period: lang === "en" ? "December 2024 - Present" : "Diciembre 2024 - Actualidad",
+    role: translations[lang].companies.bitua.role,
+    description: translations[lang].companies.bitua.description,
+    stack: [
+      "Bun",
+      "Go",
+      "Docker",
+      "Machine Learning",
+    ],
+  },
+  {
     company: "Buk",
     url: "https://buk.cl/",
-    period: lang === "en" ? "May 2022 - Present" : "Mayo 2022 - Actualidad",
+    period: lang === "en" ? "May 2022 - December 2024" : "Mayo 2022 - Diciembre 2024",
     role: translations[lang].companies.buk.role,
     description: translations[lang].companies.buk.description,
     stack: [

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -9,6 +9,14 @@ export const translations = {
     frameworks: 'Frameworks',
     other: 'Other Skills',
     companies: {
+      bitua: {
+        role: 'Senior Software Engineer',
+        description: [
+          'Building medical device applications using Bun and Go',
+          'Developing AI solutions for healthcare data',
+          'Leading system architecture and infrastructure'
+        ]
+      },
       buk: {
         role: 'Senior Software Engineer',
         description: [
@@ -61,6 +69,14 @@ export const translations = {
     frameworks: 'Frameworks',
     other: 'Otras Habilidades',
     companies: {
+      bitua: {
+        role: 'Ingeniero de Software Senior',
+        description: [
+          'Construcci\u00f3n de aplicaciones para dispositivos m\u00e9dicos con Bun y Go',
+          'Desarrollo de soluciones de IA para datos de salud',
+          'Liderando arquitectura e infraestructura de sistemas'
+        ]
+      },
       buk: {
         role: 'Ingeniero de Software Senior',
         description: [


### PR DESCRIPTION
## Summary
- add Bitua.io role translations in English and Spanish
- include Bitua.io in experience list and update Buk period

## Testing
- `npm run build` *(fails: Cannot find module '@builder.io/qwik')*

------
https://chatgpt.com/codex/tasks/task_b_684b72d6a9cc83218cdacb3ecf258c97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new experience entry for "Bitua.io" with detailed role information, description, and technology stack, available in both English and Spanish.
- **Enhancements**
  - Updated the period for the "Buk" experience to reflect an end date of December 2024, with localized date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->