### PR TITLE
feat: add games page with floating nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is a personal portfolio built with [Qwik](https://qwik.dev/) and Vi
 - **Social Links** – Quick access to GitHub and LinkedIn.
 - **Language Toggle** – Switch between English and Spanish.
 - **Interactive Effects** – A background that follows the mouse cursor.
+- **Games Page** – `/games` shows floating links to example GitHub games.
 
 ## Getting Started
 

--- a/games/index.html
+++ b/games/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/app.css" />
+    <title>Games</title>
+  </head>
+  <body class="min-h-screen w-full m-0 p-0">
+    <div id="games-app"></div>
+    <script type="module" src="/src/games-main.tsx"></script>
+  </body>
+</html>

--- a/src/components/Games.tsx
+++ b/src/components/Games.tsx
@@ -1,0 +1,66 @@
+import { component$, useVisibleTask$, useStore } from "@builder.io/qwik";
+
+interface Game {
+  name: string;
+  url: string;
+}
+
+interface NodeState {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export const Games = component$(() => {
+  const games: Game[] = [
+    { name: "Space Nodes", url: "https://github.com/galenzo17/space-nodes" },
+    { name: "Physics Puzzle", url: "https://github.com/galenzo17/physics-puzzle" },
+    { name: "Astro Shooter", url: "https://github.com/galenzo17/astro-shooter" },
+    { name: "Orbit Challenge", url: "https://github.com/galenzo17/orbit-challenge" },
+    { name: "Galactic Runner", url: "https://github.com/galenzo17/galactic-runner" },
+  ];
+
+  const nodes = useStore<NodeState[]>([]);
+
+  useVisibleTask$(({ cleanup }) => {
+    nodes.length = games.length;
+    for (let i = 0; i < games.length; i++) {
+      nodes[i] = {
+        x: Math.random() * window.innerWidth * 0.8,
+        y: Math.random() * window.innerHeight * 0.8,
+        vx: (Math.random() - 0.5) * 2,
+        vy: (Math.random() - 0.5) * 2,
+      };
+    }
+
+    const update = () => {
+      for (const node of nodes) {
+        node.x += node.vx;
+        node.y += node.vy;
+        if (node.x < 0 || node.x > window.innerWidth - 120) node.vx *= -1;
+        if (node.y < 0 || node.y > window.innerHeight - 40) node.vy *= -1;
+      }
+      id = requestAnimationFrame(update);
+    };
+
+    let id = requestAnimationFrame(update);
+    cleanup(() => cancelAnimationFrame(id));
+  });
+
+  return (
+    <section class="relative w-full h-screen overflow-hidden">
+      {games.map((game, index) => (
+        <a
+          key={game.name}
+          href={game.url}
+          target="_blank"
+          class="absolute px-4 py-2 bg-gray-800/60 rounded-lg hover:bg-purple-600/50 transition-colors"
+          style={{ transform: `translate(${nodes[index]?.x}px, ${nodes[index]?.y}px)` }}
+        >
+          {game.name}
+        </a>
+      ))}
+    </section>
+  );
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,10 @@ export const Header = component$(() => {
         <a href="tel:+5693570521" class="hover:text-purple-400 transition-colors">
           📱 +569 3570 5212
         </a>
+        <span>|</span>
+        <a href="/games/" class="hover:text-purple-400 transition-colors">
+          🕹 Games
+        </a>
       </div>
     </header>
   );

--- a/src/games-app.tsx
+++ b/src/games-app.tsx
@@ -1,0 +1,17 @@
+import { component$ } from "@builder.io/qwik";
+import { LanguageProvider } from "./context/LanguageContext";
+import { MouseFollow } from "./components/MouseFollow";
+import { Games } from "./components/Games";
+
+export const GamesApp = component$(() => {
+  return (
+    <LanguageProvider>
+      <div class="min-h-screen w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white relative overflow-hidden">
+        <MouseFollow />
+        <div class="relative z-10">
+          <Games />
+        </div>
+      </div>
+    </LanguageProvider>
+  );
+});

--- a/src/games-main.tsx
+++ b/src/games-main.tsx
@@ -1,0 +1,6 @@
+import '@builder.io/qwik/qwikloader.js'
+import { render } from '@builder.io/qwik'
+import './index.css'
+import { GamesApp } from './games-app.tsx'
+
+render(document.getElementById('games-app') as HTMLElement, <GamesApp />)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   plugins: [qwikVite({ client: { input: "src/main.tsx" } })],
   build: {
     rollupOptions: {
-      input: "index.html",
+      input: {
+        main: "index.html",
+        games: "games/index.html",
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- create `/games` page displaying floating game links
- add navigation link to the new page
- document games page in README
- update build config for multi-page output

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684b736b924c8321addb7e79b073dc2f