### PR TITLE
feat: add ascii runner animation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { component$, useContext } from '@builder.io/qwik';
 import { LanguageContext } from '../context/LanguageContext';
 import { translations } from '../i18n/translations';
+import { MarioRunner } from './MarioRunner';
 
 export const Header = component$(() => {
   const languageStore = useContext(LanguageContext);
@@ -9,6 +10,7 @@ export const Header = component$(() => {
   return (
     <header class="text-center mb-16 animate-slide-down relative pt-6">
       <div class="absolute inset-0 bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl -z-10 transform-gpu"></div>
+      <MarioRunner />
       <h1 class="text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600">
         Agustín Bereciartúa Castillo
       </h1>

--- a/src/components/MarioRunner.tsx
+++ b/src/components/MarioRunner.tsx
@@ -1,0 +1,9 @@
+import { component$ } from '@builder.io/qwik';
+
+export const MarioRunner = component$(() => {
+  return (
+    <div class="mario-runner">
+      <span class="mario">ᕕ(ᐛ)ᕗ</span>
+    </div>
+  );
+});

--- a/src/index.css
+++ b/src/index.css
@@ -91,3 +91,25 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: #5a5a5a;
 }
+@keyframes marioRun {
+  0% { transform: translateX(-10%); }
+  100% { transform: translateX(110%); }
+}
+
+.mario-runner {
+  position: absolute;
+  top: 1.5rem;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -5;
+}
+
+.mario-runner .mario {
+  display: inline-block;
+  animation: marioRun 4s linear infinite;
+  font-family: monospace;
+  white-space: pre;
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- create `MarioRunner` component with ASCII character
- run the ASCII across the header in a loop
- define `marioRun` keyframes and styling

## Testing
- `npm run build` *(fails: Cannot find module '@builder.io/qwik')*

------
https://chatgpt.com/codex/tasks/task_b_684c17a43d948321b85c5241164e6e1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an animated Mario runner visual element at the top of the header.
- **Style**
  - Added new CSS classes and animation to support the Mario runner, including horizontal movement and styling enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->