### PR TITLE
feat: add walking book background

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,16 @@ export const Header = component$(() => {
   return (
     <header class="text-center mb-16 animate-slide-down relative pt-6">
       <div class="absolute inset-0 bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl -z-10 transform-gpu"></div>
+      <div class="absolute inset-0 flex items-center justify-center -z-10 pointer-events-none">
+        <div class="book-walker">
+          <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <rect x="1" y="3" width="6" height="10" fill="#ffffff" stroke="#000000" stroke-width="1" />
+            <rect x="9" y="3" width="6" height="10" fill="#ffffff" stroke="#000000" stroke-width="1" />
+            <rect x="3" y="13" width="2" height="2" fill="#000000" />
+            <rect x="11" y="13" width="2" height="2" fill="#000000" />
+          </svg>
+        </div>
+      </div>
       <h1 class="text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600">
         Agustín Bereciartúa Castillo
       </h1>

--- a/src/index.css
+++ b/src/index.css
@@ -91,3 +91,28 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: #5a5a5a;
 }
+
+@keyframes bookWalk {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(2px);
+  }
+}
+
+.book-walker {
+  width: 24px;
+  height: 24px;
+  animation: bookWalk 0.8s steps(2) infinite;
+  position: relative;
+  pointer-events: none;
+}
+
+.book-walker svg {
+  width: 100%;
+  height: 100%;
+  shape-rendering: crispEdges;
+  image-rendering: pixelated;
+}


### PR DESCRIPTION
## Summary
- add book-walker CSS and animation
- insert animated walking book in header background

## Testing
- `npm run build` *(fails: Cannot find module '@builder.io/qwik')*

------
https://chatgpt.com/codex/tasks/task_b_684c19cde94c8321a8f8d8fc4f58b840