### PR TITLE
feat: add sticky shrinking header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,19 +15,24 @@ export const Header = component$(() => {
     return () => window.removeEventListener('scroll', onScroll);
   });
 
+  const headerClasses = `text-center mb-16 animate-slide-down transition-all duration-300 ${
+    isSticky.value ? 'fixed top-0 left-0 w-full bg-gray-900/80 backdrop-blur-sm py-2 z-40' : 'relative pt-6'
+  }`;
+  const gradientClasses = `absolute inset-0 -z-10 transform-gpu ${
+    isSticky.value ? 'hidden' : 'bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl'
+  }`;
+  const titleClasses = `font-bold mb-2 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600 ${
+    isSticky.value ? 'text-2xl' : 'text-5xl'
+  }`;
+  const roleClasses = `text-gray-300 mb-4 transition-opacity duration-300 ${
+    isSticky.value ? 'opacity-0 h-0 overflow-hidden' : 'opacity-100 text-2xl'
+  }`;
+
   return (
-    <header
-      class={`text-center mb-16 animate-slide-down transition-all duration-300 ${isSticky.value ? 'fixed top-0 left-0 w-full bg-gray-900/80 backdrop-blur-sm py-2 z-40' : 'relative pt-6'}`}
-    >
-      <div
-        class={`absolute inset-0 -z-10 transform-gpu ${isSticky.value ? 'hidden' : 'bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl'}`}
-      ></div>
-      <h1
-        class={`font-bold mb-2 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600 ${isSticky.value ? 'text-2xl' : 'text-5xl'}`}
-      >
-        Agustín Bereciartúa Castillo
-      </h1>
-      <p class={`text-gray-300 mb-4 transition-opacity duration-300 ${isSticky.value ? 'opacity-0 h-0 overflow-hidden' : 'opacity-100 text-2xl'}`}>{t.role}</p>
+    <header class={headerClasses}>
+      <div class={gradientClasses}></div>
+      <h1 class={titleClasses}>Agustín Bereciartúa Castillo</h1>
+      <p class={roleClasses}>{t.role}</p>
       <div class="flex justify-center flex-wrap gap-4 text-gray-300">
         <a href="mailto:bereciartua.agustin@gmail.com" class="hover:text-purple-400 transition-colors">
           <span class={isSticky.value ? '' : 'sm:hidden'}>📧</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,38 +1,47 @@
-import { component$, useContext } from '@builder.io/qwik';
+import { component$, useContext, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import { LanguageContext } from '../context/LanguageContext';
 import { translations } from '../i18n/translations';
 
 export const Header = component$(() => {
   const languageStore = useContext(LanguageContext);
   const t = translations[languageStore.current];
+  const isSticky = useSignal(false);
+
+  useVisibleTask$(() => {
+    const onScroll = () => {
+      isSticky.value = window.scrollY > 50;
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  });
 
   return (
-    <header class="text-center mb-16 animate-slide-down relative pt-6">
-      <div class="absolute inset-0 bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl -z-10 transform-gpu"></div>
-      <h1 class="text-5xl font-bold mb-4 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600">
+    <header
+      class={`text-center mb-16 animate-slide-down transition-all duration-300 ${isSticky.value ? 'fixed top-0 left-0 w-full bg-gray-900/80 backdrop-blur-sm py-2 z-40' : 'relative pt-6'}`}
+    >
+      <div
+        class={`absolute inset-0 -z-10 transform-gpu ${isSticky.value ? 'hidden' : 'bg-gradient-to-r from-purple-500/20 to-pink-500/20 blur-3xl'}`}
+      ></div>
+      <h1
+        class={`font-bold mb-2 bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-600 ${isSticky.value ? 'text-2xl' : 'text-5xl'}`}
+      >
         Agustín Bereciartúa Castillo
       </h1>
-      <p class="text-2xl text-gray-300 mb-4">{t.role}</p>
+      <p class={`text-gray-300 mb-4 transition-opacity duration-300 ${isSticky.value ? 'opacity-0 h-0 overflow-hidden' : 'opacity-100 text-2xl'}`}>{t.role}</p>
       <div class="flex justify-center flex-wrap gap-4 text-gray-300">
-        <a
-          href="mailto:bereciartua.agustin@gmail.com"
-          class="hover:text-purple-400 transition-colors"
-        >
-          <span class="sm:hidden">📧</span>
-          <span class="hidden sm:inline">📧 bereciartua.agustin@gmail.com</span>
+        <a href="mailto:bereciartua.agustin@gmail.com" class="hover:text-purple-400 transition-colors">
+          <span class={isSticky.value ? '' : 'sm:hidden'}>📧</span>
+          <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>📧 bereciartua.agustin@gmail.com</span>
         </a>
-        <span class="hidden sm:inline">|</span>
+        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
         <a href="/services.html" class="hover:text-purple-400 transition-colors">
-          <span class="sm:hidden">🛠️</span>
-          <span class="hidden sm:inline">{t.servicesTitle}</span>
+          <span class={isSticky.value ? '' : 'sm:hidden'}>🛠️</span>
+          <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>{t.servicesTitle}</span>
         </a>
-        <span class="hidden sm:inline">|</span>
-        <a
-          href="tel:+5693570521"
-          class="hover:text-purple-400 transition-colors"
-        >
-          <span class="sm:hidden">📱</span>
-          <span class="hidden sm:inline">📱 +569 3570 5212</span>
+        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
+        <a href="tel:+5693570521" class="hover:text-purple-400 transition-colors">
+          <span class={isSticky.value ? '' : 'sm:hidden'}>📱</span>
+          <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>📱 +569 3570 5212</span>
         </a>
       </div>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,10 +8,16 @@ export const Header = component$(() => {
   const isSticky = useSignal(false);
 
   useVisibleTask$(() => {
+    let ticking = false;
     const onScroll = () => {
-      isSticky.value = window.scrollY > 50;
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        isSticky.value = window.scrollY > 50;
+        ticking = false;
+      });
     };
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   });
 
@@ -34,18 +40,30 @@ export const Header = component$(() => {
       <h1 class={titleClasses}>Agustín Bereciartúa Castillo</h1>
       <p class={roleClasses}>{t.role}</p>
       <div class="flex justify-center flex-wrap gap-4 text-gray-300">
-        <a href="mailto:bereciartua.agustin@gmail.com" class="hover:text-purple-400 transition-colors">
-          <span class={isSticky.value ? '' : 'sm:hidden'}>📧</span>
+        <a
+          href="mailto:bereciartua.agustin@gmail.com"
+          aria-label="Email"
+          class="hover:text-purple-400 transition-colors"
+        >
+          <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>📧</span>
           <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>📧 bereciartua.agustin@gmail.com</span>
         </a>
         <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
-        <a href="/services.html" class="hover:text-purple-400 transition-colors">
-          <span class={isSticky.value ? '' : 'sm:hidden'}>🛠️</span>
+        <a
+          href="/services.html"
+          aria-label="Services"
+          class="hover:text-purple-400 transition-colors"
+        >
+          <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>🛠️</span>
           <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>{t.servicesTitle}</span>
         </a>
         <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
-        <a href="tel:+5693570521" class="hover:text-purple-400 transition-colors">
-          <span class={isSticky.value ? '' : 'sm:hidden'}>📱</span>
+        <a
+          href="tel:+56935705212"
+          aria-label="Call phone"
+          class="hover:text-purple-400 transition-colors"
+        >
+          <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>📱</span>
           <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>📱 +569 3570 5212</span>
         </a>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,7 +48,7 @@ export const Header = component$(() => {
           <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>📧</span>
           <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>📧 bereciartua.agustin@gmail.com</span>
         </a>
-        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
+        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`}>|</span>
         <a
           href="/services.html"
           aria-label="Services"
@@ -57,7 +57,7 @@ export const Header = component$(() => {
           <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>🛠️</span>
           <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>{t.servicesTitle}</span>
         </a>
-        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`>|</span>
+        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`}>|</span>
         <a
           href="tel:+56935705212"
           aria-label="Call phone"

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,4 +1,4 @@
-import { component$, useContext, QRL } from "@builder.io/qwik";
+import { component$, useContext, QRL, useSignal, useVisibleTask$ } from "@builder.io/qwik";
 import { LanguageContext } from "../context/LanguageContext";
 
 interface LanguageToggleProps {
@@ -8,11 +8,26 @@ interface LanguageToggleProps {
 export const LanguageToggle = component$<LanguageToggleProps>(
   ({ toggleLanguage }) => {
     const languageStore = useContext(LanguageContext);
+    const hideToggle = useSignal(false);
+
+    useVisibleTask$(() => {
+      let ticking = false;
+      const onScroll = () => {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(() => {
+          hideToggle.value = window.scrollY > 50;
+          ticking = false;
+        });
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      return () => window.removeEventListener('scroll', onScroll);
+    });
 
     return (
       <button
         onClick$={toggleLanguage}
-        class="fixed top-4 right-4 px-4 py-2 bg-gray-800/80 rounded-full hover:bg-purple-500/20 transition-all transform hover:scale-110 z-50 flex items-center gap-1"
+        class={`fixed top-4 right-4 px-4 py-2 bg-gray-800/80 rounded-full hover:bg-purple-500/20 transition-all transform hover:scale-110 z-50 flex items-center gap-1 ${hideToggle.value ? 'hidden' : ''}`}
       >
         {languageStore.current === "en" ? (
           <>


### PR DESCRIPTION
## Summary
- add scroll listener to change header style when page scrolls
- display compact header with icons only while scrolling

## Testing
- `npm run build` *(fails: missing dependencies, no internet access)*

------
https://chatgpt.com/codex/tasks/task_b_684c1a586ddc8321adc9adc41cec8b96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Header now becomes sticky and compact when scrolling past 50 pixels, providing improved navigation accessibility.
  - Smooth transitions and animations enhance the visual experience during header state changes.
  - Navigation and contact links adapt their display for better clarity and responsiveness when the header is sticky.
  - Accessibility improvements added with aria-labels on navigation and contact links.
  - Phone contact number corrected for accurate dialing.
  - Language toggle button hides automatically when scrolling beyond 50 pixels for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->