### PR TITLE
feat: add asteroids game page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The latest version of the portfolio is available at [agustin-dev.me](https://agu
 - **Social Links** – Quick access to GitHub and LinkedIn.
 - **Language Toggle** – Switch between English and Spanish.
 - **Interactive Effects** – A background that follows the mouse cursor.
+- **Asteroids Game** – Play a simple clone at `/games`.
 
 ## Getting Started
 

--- a/games.html
+++ b/games.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Classic asteroids game clone." />
+    <title>Asteroids Game</title>
+    <link rel="stylesheet" href="/src/app.css" />
+    <style>
+      body { margin: 0; background: #000; overflow: hidden; }
+      canvas { display: block; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script type="module" src="/src/games/asteroids.js"></script>
+  </body>
+</html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -59,6 +59,15 @@ export const Header = component$(() => {
         </a>
         <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`}>|</span>
         <a
+          href="/games.html"
+          aria-label="Games"
+          class="hover:text-purple-400 transition-colors"
+        >
+          <span aria-hidden="true" class={isSticky.value ? '' : 'sm:hidden'}>🎮</span>
+          <span class={isSticky.value ? 'hidden' : 'hidden sm:inline'}>{t.gamesTitle}</span>
+        </a>
+        <span class={`hidden sm:inline ${isSticky.value ? 'hidden' : ''}`}>|</span>
+        <a
           href="tel:+56935705212"
           aria-label="Call phone"
           class="hover:text-purple-400 transition-colors"

--- a/src/games/asteroids.js
+++ b/src/games/asteroids.js
@@ -1,0 +1,162 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+class Vector {
+  constructor(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+  }
+  add(v) {
+    this.x += v.x;
+    this.y += v.y;
+  }
+  scale(n) {
+    this.x *= n;
+    this.y *= n;
+  }
+  static fromAngle(angle) {
+    return new Vector(Math.cos(angle), Math.sin(angle));
+  }
+}
+
+class Ship {
+  constructor() {
+    this.pos = new Vector(canvas.width / 2, canvas.height / 2);
+    this.vel = new Vector();
+    this.angle = 0;
+  }
+  update() {
+    this.pos.add(this.vel);
+    this.pos.x = (this.pos.x + canvas.width) % canvas.width;
+    this.pos.y = (this.pos.y + canvas.height) % canvas.height;
+    this.vel.scale(0.99);
+  }
+  draw() {
+    ctx.save();
+    ctx.translate(this.pos.x, this.pos.y);
+    ctx.rotate(this.angle);
+    ctx.beginPath();
+    ctx.moveTo(10, 0);
+    ctx.lineTo(-10, 7);
+    ctx.lineTo(-10, -7);
+    ctx.closePath();
+    ctx.strokeStyle = '#fff';
+    ctx.stroke();
+    ctx.restore();
+  }
+  thrust() {
+    const force = Vector.fromAngle(this.angle);
+    force.scale(0.1);
+    this.vel.add(force);
+  }
+  rotate(dir) {
+    this.angle += dir;
+  }
+}
+
+class Asteroid {
+  constructor() {
+    this.pos = new Vector(Math.random() * canvas.width, Math.random() * canvas.height);
+    this.vel = new Vector(Math.random() * 2 - 1, Math.random() * 2 - 1);
+    this.size = Math.random() * 40 + 20;
+  }
+  update() {
+    this.pos.add(this.vel);
+    this.pos.x = (this.pos.x + canvas.width) % canvas.width;
+    this.pos.y = (this.pos.y + canvas.height) % canvas.height;
+  }
+  draw() {
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, this.size, 0, Math.PI * 2);
+    ctx.strokeStyle = '#888';
+    ctx.stroke();
+  }
+}
+
+class Bullet {
+  constructor(position, angle) {
+    this.pos = new Vector(position.x, position.y);
+    this.vel = Vector.fromAngle(angle);
+    this.vel.scale(5);
+  }
+  update() {
+    this.pos.add(this.vel);
+  }
+  draw() {
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(this.pos.x, this.pos.y, 2, 2);
+  }
+  isOut() {
+    return this.pos.x < 0 || this.pos.x > canvas.width || this.pos.y < 0 || this.pos.y > canvas.height;
+  }
+}
+
+const ship = new Ship();
+const asteroids = [];
+for (let i = 0; i < 5; i++) {
+  asteroids.push(new Asteroid());
+}
+const bullets = [];
+const keys = {};
+
+document.addEventListener('keydown', (e) => {
+  keys[e.code] = true;
+  if (e.code === 'Space') {
+    bullets.push(new Bullet(ship.pos, ship.angle));
+  }
+});
+
+document.addEventListener('keyup', (e) => {
+  keys[e.code] = false;
+});
+
+function update() {
+  if (keys.ArrowLeft) {
+    ship.rotate(-0.05);
+  }
+  if (keys.ArrowRight) {
+    ship.rotate(0.05);
+  }
+  if (keys.ArrowUp) {
+    ship.thrust();
+  }
+  ship.update();
+  for (const a of asteroids) {
+    a.update();
+  }
+  for (const bullet of bullets) {
+    bullet.update();
+  }
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ship.draw();
+  for (const a of asteroids) {
+    a.draw();
+  }
+  for (const bullet of bullets) {
+    bullet.draw();
+  }
+}
+
+function loop() {
+  update();
+  draw();
+  for (let i = bullets.length - 1; i >= 0; i--) {
+    if (bullets[i].isOut()) {
+      bullets.splice(i, 1);
+    }
+  }
+  requestAnimationFrame(loop);
+}
+
+loop();

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -9,6 +9,7 @@ export const translations = {
     frameworks: 'Frameworks',
     other: 'Other Skills',
     servicesTitle: 'Services',
+    gamesTitle: 'Games',
     servicesIntro: 'I offer software engineering and AI solutions tailored to your needs.',
     serviceList: [
       {
@@ -89,6 +90,7 @@ export const translations = {
     frameworks: 'Frameworks',
     other: 'Otras Habilidades',
     servicesTitle: 'Servicios',
+    gamesTitle: 'Juegos',
     servicesIntro: 'Ofrezco servicios de ingeniería de software e IA adaptados a tus necesidades.',
     serviceList: [
       {


### PR DESCRIPTION
## Summary
- add `/games` page with simple Asteroids clone
- link new page from the header
- add `gamesTitle` translations for EN and ES
- document the new game in the README

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6850aa61474c8321a2640cb4b836982d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an Asteroids-style game accessible from the portfolio at the /games path.
	- Added a dedicated Games page with an interactive Asteroids game.
	- Included a new navigation link to the Games page in the site header.
- **Documentation**
	- Updated the README to mention the new Asteroids game feature.
- **Style**
	- Added translations for the Games navigation link in English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->